### PR TITLE
Added 'pageChange' event to ScrollController

### DIFF
--- a/docs/ScrollController.md
+++ b/docs/ScrollController.md
@@ -17,7 +17,7 @@ Events:
 |-----------|-----------|
 |scrollstart|Emitted when scrolling starts.|
 |scroll     |Emitted as the content scrolls (once for each frame the visible offset has changed)|
-|pagechange |Emitted as scrolling stops if ScrollController is paginated and visible page has changed.|
+|pagechange |Emitted whenever visible page changes and options.paging is set to true.|
 |scrollend  |Emitted after scrolling stops (when the scroll particle settles).|
 
 Inherited from: [LayoutController](./LayoutController.md)


### PR DESCRIPTION
Added `pageChange` event just before `scrollend` is emitted (given that the page has changed...). Unsure whether it belongs there or if it should trigger while scrolling, as soon as a new page covers more than 50% of visible area.

I used the sequence index for the event data to provide compatibility with famo.us Scrollview.

Should close issue #23 
