### PR TITLE
fix(app): Fix npm package

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
     "type": "git",
     "url": "git://github.com/IjzerenHein/famous-flex.git"
   },
+  "main": "dist/famous-flex-global.template.js",
   "browserify": {
     "transform": [
       "browserify-shim",
@@ -80,6 +81,7 @@
   },
   "files": [
     "src",
+    "dist/famous-flex-global.template.js",
     "LICENSE"
   ]
 }


### PR DESCRIPTION
Changes to allow the library to be used via `npm install`, using `require('famous-flex')` on the consumer side