### PR TITLE
CollectionLayout docs: clarify scroll vs layout direction #2 - in doc source

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,11 @@
+# Contributing to famous-flex
+
+## Documentation
+
+Please note that documentation (i.e. everything in the `docs` directory) is
+**automatically generated**.  As such, contributions should be made to the
+respective `.js` source file used to generate the final markdown.
+
+e.g. `src/layouts/CollectionLayout.js` contains the source documentation
+used to generate `docs/layouts/CollectionLayout.md`.  Only the former
+should be modified.

--- a/src/layouts/CollectionLayout.js
+++ b/src/layouts/CollectionLayout.js
@@ -58,6 +58,13 @@
  *   ]
  * });
  * ```
+ *
+ * Notes:
+ *
+ * * Recall that the **`direction`** option is given to `FlexScrollView` and not
+ * the `ColllectionLayout`.  As such, it affects *scroll direction* and not
+ * *layout direction*.  With direction `Y`, items are *laid out horizontally*,
+ * but multiple rows *scroll vertically*, and this is the correct behaviour.
  * @module
  */
 define(function(require, exports, module) {


### PR DESCRIPTION
Successor of PR https://github.com/IjzerenHein/famous-flex/pull/62 as originally discussed in https://github.com/IjzerenHein/famous-flex/issues/61#issuecomment-73406038.

I also created an initial CONTRIBUTING.md which explains that the docs are automatically generated.