### PR TITLE
HeaderFooterLayout: coersion of headerSize || headerHeight causes {headerSize: 0} to be ignored

### DIFF
--- a/src/layouts/HeaderFooterLayout.js
+++ b/src/layouts/HeaderFooterLayout.js
@@ -45,8 +45,8 @@ define(function(require, exports, module) {
     // Layout function
     module.exports = function HeaderFooterLayout(context, options) {
         var dock = new LayoutDockHelper(context, options);
-        dock.top('header', options.headerSize || options.headerHeight);
-        dock.bottom('footer', options.footerSize || options.footerHeight);
+        dock.top('header', options.headerSize === 0 ? 0 : options.headerSize || options.headerHeight);
+        dock.bottom('footer', options.footerSize === 0 ? 0 : options.footerSize || options.footerHeight);
         dock.fill('content');
     };
 });


### PR DESCRIPTION
```javascript
dock.top('header', options.headerSize || options.headerHeight);
dock.bottom('footer', options.footerSize || options.footerHeight);
```
This code means that if options `{headerSize: 0, footerSize: 0}` are sent to HeaderFooterLayout the layout will use the height of the node instead of the expected `0`.

My solution is to explicitly handle `headerSize: 0`.

Another solution would be make there be only one valid key "headerSize" or "headerHeight" as accepting either can be confusing.