### PR TITLE
emit touchstart and touchend

### DIFF
--- a/src/ScrollController.js
+++ b/src/ScrollController.js
@@ -480,6 +480,8 @@ define(function(require, exports, module) {
             this.applyScrollForce(0);
             this._scroll.touchDelta = 0;
         }
+        
+        this._eventOutput.emit('touchstart', event);
     }
 
     /**
@@ -574,6 +576,8 @@ define(function(require, exports, module) {
         var delta = this._scroll.touchDelta;
         this.releaseScrollForce(delta, velocity);
         this._scroll.touchDelta = 0;
+        
+        this._eventOutput.emit('touchend', event);
     }
 
     /**


### PR DESCRIPTION
Better user experience for users to do linked scrolling between a single vertical FlexScrollView holding multiple horizontal FlexScrollViews. Previously using only scrollend instead of touchend results in any scrolling being blocked until scrollend (where, instead a user would expect to be able to scroll something else as soon as their finger is lifted). 

Horizontal scrollers (create multiple of these): 
    var elem = ...a FlexScrollView;
    HorizontalScrolls.push(elem);
    elem.on('scrollstart', function(event) {
        VerticalFlex.setOptions({ enabled: false });
        elem.setOptions({ touchMoveDirectionThresshold: undefined });
    });
    elem.on(['scrollstop','touchend','touchcancel'], function(event) {
        VerticalFlex.setOptions({ enabled: true });
        elem.setOptions({ touchMoveDirectionThresshold: 0.2 });
    });

Vertical scroller: 
    // When the vertical scrollview starts scrolling, capture all events
    // and disable scrolling on the horizontal scrollview
    VerticalFlex.on('scrollstart', function(event) {
        HorizontalScrolls.forEach(function(hView){
            hView.setOptions({ enabled: false });
        });
        VerticalFlex.setOptions({ touchMoveDirectionThresshold: undefined });
    });
    VerticalFlex.on(['scrollstop','touchend','touchcancel'], function(event) {
        HorizontalScrolls.forEach(function(hView){
            hView.setOptions({ enabled: true });
        });
        VerticalFlex.setOptions({ touchMoveDirectionThresshold: 0.5 });
    });