### PR TITLE
Added warning to ListLayout when options.spacing is non-numeric

### DIFF
--- a/src/layouts/ListLayout.js
+++ b/src/layouts/ListLayout.js
@@ -113,7 +113,15 @@ define(function(require, exports, module) {
         var bound;
 
         //
-        // reset size & translation
+        // Sanity checks
+        //
+        if(spacing && typeof spacing !== 'number'){
+            console.log('Famous-flex warning: ListLayout was initialized with a non-numeric spacing option. ' +
+                'The CollectionLayout supports an array spacing argument, but the ListLayout does not.');
+        }
+
+        //
+        // Reset size & translation
         //
         set.size[0] = size[0];
         set.size[1] = size[1];


### PR DESCRIPTION
The CollectionLayout supports array-based spacing options, and the ListLayout does not.
    
    If an array spacing option is given to ListLayout (after switching from CollectionLayout back to ListLayout for example), it does not warn or throw an exception, but rather doesn't show any renderables without notice. This commit fixes that behaviour by letting the developer know that the spacing should be numeric.